### PR TITLE
Compatible wepback3.X

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -18,15 +18,19 @@ export default class HtmlWebpackInjectPlugin {
   }
 
   apply = (compiler) => {
-    compiler.hooks.compilation.tap('HtmlWebpackInjectPlugin', (compilation) => {
-      compilation.hooks.htmlWebpackPluginAlterAssetTags.tapAsync('HtmlWebpackInjectPlugin', (htmlPluginData, cb) => {
-        if (this.parent === 'head') {
-          htmlPluginData.head = htmlPluginData.head.concat(this.assets)
-        } else {
-          htmlPluginData.body = this.assets.concat(htmlPluginData.body)
-        }
-        return cb(null, htmlPluginData)
+    (compiler.hooks
+      ? compiler.hooks.compilation.tap.bind(compiler.hooks.compilation, 'HtmlWebpackInjectPlugin')
+      : compiler.plugin.bind(compiler, 'compilation'))(compilation => {
+        (compilation.hooks
+        ? compilation.hooks.htmlWebpackPluginAlterAssetTags.tapAsync.bind(compilation.hooks.htmlWebpackPluginAlterAssetTags, 'HtmlWebpackInjectPlugin')
+        : compilation.plugin.bind(compilation, 'html-webpack-plugin-alter-asset-tags'))((htmlPluginData, cb) => {
+          if (this.parent === 'head') {
+            htmlPluginData.head = htmlPluginData.head.concat(this.assets)
+          } else {
+            htmlPluginData.body = this.assets.concat(htmlPluginData.body)
+          }
+          return cb(null, htmlPluginData)
+        })
       })
-    })
   }
 }


### PR DESCRIPTION
I am very emotional about the plug-in written by the author, which is very useful, but the webpack3.x I am using now will prompt the compiler. Hook to be undefined, which cannot be upgraded. By comparing the differences between webpack3.x and webpack4.x, some changes have been made to make it compatible with both webpack3.x and webpack4.x. I hope the author can combine my PR.